### PR TITLE
Skips output on failed test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ This template may be customized to fit your needs.
 By default, the docs are output to `api_docs.md` in the root of the Rails project.
 You can change this by altering the config in `test_helper.rb` or `rails_helper.rb`.
 
+Note that docs are not generated if the suite fails.
+
 ## Additional Features
 
 #### Skipping documentation on tests

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -60,12 +60,18 @@ class SmarfDoc
     end
   end
 
+  def all_completed?
+    @tests.none? {|t| t.request.nil? }
+  end
+
 # = = = =
 
   def self.finish!
-    current.sort_by_url!
-    current.output_testcases_to_file
-    current.clean_up!
+    if current.all_completed?
+      current.sort_by_url!
+      current.output_testcases_to_file
+      current.clean_up!
+    end
   end
 
   def self.run!(request, response)


### PR DESCRIPTION
Heyo!

I'm using this for some quick n' dirty docs on a project and noticed spec failures were resulting in an extra error thrown from smarf_doc.

```
Failure/Error: config.after(:suite) { SmarfDoc.finish! }                                                               
                                                                                                                          
NoMethodError:                                                                                                         
  undefined method `path' for nil:NilClass                                                                             
# /usr/local/bundle/gems/smarf_doc-1.0.0/lib/base.rb:12:in `block in sort_by_url!'                       
# /usr/local/bundle/gems/smarf_doc-1.0.0/lib/base.rb:11:in `sort!'                                                     
# /usr/local/bundle/gems/smarf_doc-1.0.0/lib/base.rb:11:in `sort_by_url!'                                              
# /usr/local/bundle/gems/smarf_doc-1.0.0/lib/base.rb:66:in `finish!'                                                   
# ./spec/rails_helper.rb:106:in `block (2 levels) in <top (required)>' 
```

Also, not a huge deal but SD output was clobbering our .md even on failed runs